### PR TITLE
Enable coarse to fine training

### DIFF
--- a/opensplat.cpp
+++ b/opensplat.cpp
@@ -20,8 +20,8 @@ int main(int argc, char *argv[]){
         
         ("n,num-iters", "Number of iterations to run", cxxopts::value<int>()->default_value("30000"))
         ("d,downscale-factor", "Scale input images by this factor.", cxxopts::value<float>()->default_value("1"))
-        ("num-downscales", "Number of images downscales to use. After being scaled by [downscale-factor], images are initially scaled by a further (2^[num-downscales]) and the scale is increased every [resolution-schedule]", cxxopts::value<int>()->default_value("3"))
-        ("resolution-schedule", "Double the image resolution every these many steps", cxxopts::value<int>()->default_value("250"))
+        ("num-downscales", "Number of images downscales to use. After being scaled by [downscale-factor], images are initially scaled by a further (2^[num-downscales]) and the scale is increased every [resolution-schedule]", cxxopts::value<int>()->default_value("2"))
+        ("resolution-schedule", "Double the image resolution every these many steps", cxxopts::value<int>()->default_value("3000"))
         ("sh-degree", "Maximum spherical harmonics degree (must be > 0)", cxxopts::value<int>()->default_value("3"))
         ("sh-degree-interval", "Increase the number of spherical harmonics degree after these many steps (will not exceed [sh-degree])", cxxopts::value<int>()->default_value("1000"))
         ("ssim-weight", "Weight to apply to the structural similarity loss. Set to zero to use least absolute deviation (L1) loss only", cxxopts::value<float>()->default_value("0.2"))


### PR DESCRIPTION
Hello,
Since this repo is using method from `splatfacto`, recently nerfstudio's developer change 2 hyperparameters for activating coarse-to-fine training. See this thread for disscussion : [Enable coarse-to-fine training](https://github.com/nerfstudio-project/nerfstudio/pull/2984)

It proved increase the quality a little bit in original splatfacto. Jb-ye and me already proved in some datasets. But, I never tested in this repo. I believe it also works in this repo too.