### PR TITLE
Add MacOS build pipeline

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,6 +34,7 @@ jobs:
       CL: /MP
       CMAKE_GENERATOR: Ninja
       CMAKE_GENERATOR_PLATFORM: ${{matrix.arch}}
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -42,8 +43,27 @@ jobs:
 
       - name: Setup MacOS
         run: |
-          brew update || brew update-reset &&
-          brew upgrade &&
+          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+            # brew install in macos-13 runner image is broken
+            # https://github.com/actions/runner-images/issues/9471
+            brew unlink python@3.11
+            brew unlink python@3.12
+            brew uninstall --force azure-cli
+            brew uninstall --force aws-sam-cli
+            brew uninstall --force pipx
+            brew uninstall --force python@3.11
+            brew uninstall --force python@3.12
+            rm -f '/usr/local/bin/2to3'
+            rm -f '/usr/local/bin/2to3-3.12'
+            rm -f '/usr/local/bin/idle3'
+            rm -f '/usr/local/bin/idle3.12'
+            rm -f '/usr/local/bin/pydoc3'
+            rm -f '/usr/local/bin/pydoc3.12'
+            rm -f '/usr/local/bin/python3'
+            rm -f '/usr/local/bin/python3-config'
+            rm -f '/usr/local/bin/python3.12'
+            rm -f '/usr/local/bin/python3.12-config'
+          fi
           brew install \
             ccache \
             cmake \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,10 +16,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14] # [macos-14, macos-13, macos-12, macos-11]
-        arch: [arm64] # [arm64, x86_64]
-        torch-version: [2.2.1] # [2.2.1, 2.2.0, 2.1.2, 2.1.1, 2.1.0, 2.0.0, 1.13.0, 1.12.0]
+        os: [macos-14, macos-13] # [macos-14, macos-13, macos-12, macos-11]
+        arch: [arm64, x86_64] # [arm64, x86_64]
+        torch-version: [2.2.1, 2.1.2] # [2.2.1, 2.2.0, 2.1.2, 2.1.1, 2.1.0, 2.0.0, 1.13.0, 1.12.0]
         cmake-build-type: [Release] # [Debug, ClangTidy]
+        exclude:
+          - os: macos-14
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
+            torch-version: 2.1.2
+          - os: macos-13
+            arch: arm64
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       CCACHE_BASEDIR: ${{ github.workspace }}
@@ -34,6 +42,8 @@ jobs:
 
       - name: Setup MacOS
         run: |
+          brew update || brew update-reset &&
+          brew upgrade &&
           brew install \
             ccache \
             cmake \
@@ -51,6 +61,14 @@ jobs:
       - name: Install LibTorch
         if: ${{ steps.libtorch-cache.outputs.cache-hit != 'true' }}
         run: |
+          TORCH_VER_FULL=${{ matrix.torch-version }}
+          TORCH_VER_ARR=($(echo ${TORCH_VER_FULL} | tr "." " "))
+          TORCH_VER="${TORCH_VER_ARR[0]}.${TORCH_VER_ARR[1]}"
+          if [[ "${TORCH_VER}" == "2.2" ]]; then
+            wget --no-check-certificate -nv https://download.pytorch.org/libtorch/cpu/libtorch-macos-${{ matrix.arch }}-${{ matrix.torch-version }}.zip -O libtorch.zip
+          else
+            wget --no-check-certificate -nv https://download.pytorch.org/libtorch/cpu/libtorch-macos-${{ matrix.torch-version }}.zip -O libtorch.zip
+          fi
           wget --no-check-certificate -nv https://download.pytorch.org/libtorch/cpu/libtorch-macos-${{ matrix.arch }}-${{ matrix.torch-version }}.zip -O libtorch.zip
           unzip -q ${{ github.workspace }}/libtorch.zip -d ${{ github.workspace }}/
           rm ${{ github.workspace }}/libtorch.zip
@@ -84,7 +102,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: |
-            build/libgsplat.a
+            build/libgsplat_cpu.a
             build/opensplat
             build/simple_trainer
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: OpenSplat (MacOS X86 and ARM)
 on:
   push:
     branches:
-      - macos-build
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -89,7 +89,6 @@ jobs:
           else
             wget --no-check-certificate -nv https://download.pytorch.org/libtorch/cpu/libtorch-macos-${{ matrix.torch-version }}.zip -O libtorch.zip
           fi
-          wget --no-check-certificate -nv https://download.pytorch.org/libtorch/cpu/libtorch-macos-${{ matrix.arch }}-${{ matrix.torch-version }}.zip -O libtorch.zip
           unzip -q ${{ github.workspace }}/libtorch.zip -d ${{ github.workspace }}/
           rm ${{ github.workspace }}/libtorch.zip
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,107 @@
+name: OpenSplat (MacOS X86 and ARM)
+
+on:
+  push:
+    branches:
+      - macos-build
+  pull_request:
+    types: [ assigned, opened, synchronize, reopened ]
+  release:
+    types: [ published, edited ]
+
+jobs:
+  build:
+    name: ${{ matrix.os }}-${{ matrix.arch }}-torch-${{ matrix.torch-version }}-${{ matrix.cmake-build-type }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14] # [macos-14, macos-13, macos-12, macos-11]
+        arch: [arm64] # [arm64, x86_64]
+        torch-version: [2.2.1] # [2.2.1, 2.2.0, 2.1.2, 2.1.1, 2.1.0, 2.0.0, 1.13.0, 1.12.0]
+        cmake-build-type: [Release] # [Debug, ClangTidy]
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CL: /MP
+      CMAKE_GENERATOR: Ninja
+      CMAKE_GENERATOR_PLATFORM: ${{matrix.arch}}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup MacOS
+        run: |
+          brew install \
+            cmake \
+            ninja \
+            opencv
+          wget -nv https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1-darwin.tar.gz
+          sudo tar xzf ccache-4.9.1-darwin.tar.gz -C /usr/bin --strip-components=1 --no-same-owner ccache-4.9.1-darwin/ccache
+          rm -f ccache-*-darwin.tar.gz
+          ccache --version
+
+      - name: Sudo Tar Wrapper
+        run: |
+          # Workaround: https://github.com/containers/podman/discussions/17868
+          sudo mv -fv /usr/bin/tar /usr/bin/tar.orig
+          echo -e '#!/bin/sh\n\nsudo /usr/bin/tar.orig "$@"' | sudo tee -a /usr/bin/tar
+          sudo chmod +x /usr/bin/tar
+
+      - name: Restore LibTorch Cache
+        uses: actions/cache@v4
+        id: libtorch-cache
+        with:
+          key: libtorch-${{ matrix.torch-version }}-macos-${{ matrix.arch }}
+          path: |
+            ${{ github.workspace }}/libtorch
+
+      - name: Install LibTorch
+        if: ${{ steps.libtorch-cache.outputs.cache-hit != 'true' }}
+        run: |
+          wget --no-check-certificate -nv https://download.pytorch.org/libtorch/cpu/libtorch-macos-${{ matrix.arch }}-${{ matrix.torch-version }}.zip -O libtorch.zip
+          unzip -q ${{ github.workspace }}/libtorch.zip -d ${{ github.workspace }}/
+          rm ${{ github.workspace }}/libtorch.zip
+
+      - name: Cache Build
+        uses: actions/cache@v4
+        id: cache-builds
+        with:
+          key: ${{ matrix.os }}-${{ matrix.arch }}-torch-${{ matrix.cmake-build-type }}-ccache-${{ github.run_id }}
+          restore-keys: ${{ matrix.os }}-cpu-torch-${{ matrix.cmake-build-type }}-ccache-
+          path: ${{ env.CCACHE_DIR }}
+
+      - name: Configure And Build
+        run: |
+          set -x
+          mkdir build
+          cd build
+          cmake .. \
+            -G${CMAKE_GENERATOR} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=$(which ccache) \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache) \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/libtorch \
+            -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install \
+            -DOPENSPLAT_BUILD_SIMPLE_TRAINER=ON
+          ninja
+          ls -l .
+
+      - name: Save Artifacts
+        if: ${{ matrix.os == 'macos-14' && matrix.arch == 'arm64' && matrix.torch-version == '2.2.1' && matrix.cmake-build-type == 'Release' }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: |
+            build/libgsplat.a
+            build/opensplat
+            build/simple_trainer
+
+      - name: Clean Compiler Cache
+        run: |
+          set -x
+          ccache --show-stats
+          ccache --evict-older-than 7d
+          ccache -s
+          ccache --show-stats

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,13 +35,10 @@ jobs:
       - name: Setup MacOS
         run: |
           brew install \
+            ccache \
             cmake \
             ninja \
             opencv
-          wget -nv https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1-darwin.tar.gz
-          sudo tar xzf ccache-4.9.1-darwin.tar.gz -C /usr/bin --strip-components=1 --no-same-owner ccache-4.9.1-darwin/ccache
-          rm -f ccache-*-darwin.tar.gz
-          ccache --version
 
       - name: Sudo Tar Wrapper
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,13 +40,6 @@ jobs:
             ninja \
             opencv
 
-      - name: Sudo Tar Wrapper
-        run: |
-          # Workaround: https://github.com/containers/podman/discussions/17868
-          sudo mv -fv /usr/bin/tar /usr/bin/tar.orig
-          echo -e '#!/bin/sh\n\nsudo /usr/bin/tar.orig "$@"' | sudo tee -a /usr/bin/tar
-          sudo chmod +x /usr/bin/tar
-
       - name: Restore LibTorch Cache
         uses: actions/cache@v4
         id: libtorch-cache


### PR DESCRIPTION
MacOS build is now working for both arm64 and x86-64 arch

Build matrix:
- macos-14-arm64-torch-2.2.1-Release
- macos-13-x86-64-torch-2.2.1-Release
- macos-13-x86-64-torch-2.1.2-Release

We can enable the builds for [macos-11 and macos-12]( https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) when it's needed