### PR TITLE
Added SimpleRadial camera model to colmap.cpp

### DIFF
--- a/colmap.cpp
+++ b/colmap.cpp
@@ -58,7 +58,7 @@ InputData inputDataFromColmap(const std::string &projectRoot){
             cam->fy = cam->fx;
             cam->cx = readBinary<double>(camf);
             cam->cy = readBinary<double>(camf);
-            cam->k = readBinary<double>(camf);
+            cam->k1 = readBinary<double>(camf);
         }else if (model == OpenCV){
             cam->fx = readBinary<double>(camf);
             cam->fy = readBinary<double>(camf);

--- a/colmap.cpp
+++ b/colmap.cpp
@@ -53,6 +53,12 @@ InputData inputDataFromColmap(const std::string &projectRoot){
             cam->fy = readBinary<double>(camf);
             cam->cx = readBinary<double>(camf);
             cam->cy = readBinary<double>(camf);
+        }else if (model == SimpleRadial){
+            cam->fx = readBinary<double>(camf);
+            cam->fy = cam->fx;
+            cam->cx = readBinary<double>(camf);
+            cam->cy = readBinary<double>(camf);
+            cam->k = readBinary<double>(camf);
         }else if (model == OpenCV){
             cam->fx = readBinary<double>(camf);
             cam->fy = readBinary<double>(camf);


### PR DESCRIPTION
Added the SimpleRadial camera model to colmap.cpp from https://github.com/colmap/colmap/blob/0ea2d5ceee1360bba427b2ef61f1351e59a46f91/src/colmap/sensor/models.h#L235

Copied syntax found in SimplePinhole, copying fy=fx for the models with only one focal length parameter, like SimpleRadial.

I'm new to c++ so I'm not 100% sure how to test the code.