### PR TITLE
Add .splat compression output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A free and open source implementation of 3D [gaussian splatting](https://www.you
 <img src="https://github.com/pierotofy/OpenSplat/assets/1951843/c9327c7c-31ad-402d-a5a5-04f7602ca5f5" width="49%" />
 <img src="https://github.com/pierotofy/OpenSplat/assets/1951843/eba4ae75-2c88-4c9e-a66b-608b574d085f" width="49%" />
 
-OpenSplat takes camera poses + sparse points in [COLMAP](https://colmap.github.io/), [OpenSfM](https://github.com/mapillary/OpenSfM), [ODM](https://github.com/OpenDroneMap/ODM) or [nerfstudio](https://docs.nerf.studio/quickstart/custom_dataset.html) project format and computes a [scene file](https://drive.google.com/file/d/12lmvVWpFlFPL6nxl2e2d-4u4a31RCSKT/view?usp=sharing) (.ply) that can be later imported for [viewing](https://antimatter15.com/splat/?url=https://splat.uav4geo.com/banana.splat), editing and rendering in other [software](https://github.com/MrNeRF/awesome-3D-gaussian-splatting?tab=readme-ov-file#open-source-implementations).
+OpenSplat takes camera poses + sparse points in [COLMAP](https://colmap.github.io/), [OpenSfM](https://github.com/mapillary/OpenSfM), [ODM](https://github.com/OpenDroneMap/ODM) or [nerfstudio](https://docs.nerf.studio/quickstart/custom_dataset.html) project format and computes a [scene file](https://drive.google.com/file/d/12lmvVWpFlFPL6nxl2e2d-4u4a31RCSKT/view?usp=sharing) (.ply or .splat) that can be later imported for [viewing](https://antimatter15.com/splat/?url=https://splat.uav4geo.com/banana.splat), editing and rendering in other [software](https://github.com/MrNeRF/awesome-3D-gaussian-splatting?tab=readme-ov-file#open-source-implementations).
 
 Graphics card recommended, but not required! OpenSplat runs the fastest on NVIDIA, AMD and Apple (Metal) GPUs, but can also run entirely on the CPU (~100x slower).
 
@@ -223,6 +223,16 @@ There's several parameters you can tune. To view the full list:
 ./opensplat --help
 ```
 
+### Compression
+
+To generate compressed splats (.splat files), use the `-o` option:
+
+```bash
+./opensplat /path/to/banana -o banana.splat
+```
+
+### AMD GPU Notes
+
 To train a model with AMD GPU using docker container, you can use the following command as a reference:
 1. Launch the docker container with the following command:
 ```bash
@@ -243,7 +253,6 @@ We recently released OpenSplat, so there's lots of work to do.
  * Improve speed / reduce memory usage
  * Distributed computation using multiple machines
  * Real-time training viewer output
- * Compressed scene outputs
  * Automatic filtering
  * Your ideas?
 

--- a/model.hpp
+++ b/model.hpp
@@ -81,7 +81,9 @@ struct Model{
   void schedulersStep(int step);
   int getDownscaleFactor(int step);
   void afterTrain(int step);
-  void savePlySplat(const std::string &filename);
+  void save(const std::string &filename);
+  void savePly(const std::string &filename);
+  void saveSplat(const std::string &filename);
   void saveDebugPly(const std::string &filename);
   torch::Tensor mainLoss(torch::Tensor &rgb, torch::Tensor &gt, float ssimWeight);
 

--- a/opensplat.cpp
+++ b/opensplat.cpp
@@ -135,7 +135,7 @@ int main(int argc, char *argv[]){
 
             if (saveEvery > 0 && step % saveEvery == 0){
                 fs::path p(outputScene);
-                model.savePlySplat((p.replace_filename(fs::path(p.stem().string() + "_" + std::to_string(step) + p.extension().string())).string()));
+                model.save((p.replace_filename(fs::path(p.stem().string() + "_" + std::to_string(step) + p.extension().string())).string()));
             }
 
             if (!valRender.empty() && step % 10 == 0){
@@ -146,7 +146,7 @@ int main(int argc, char *argv[]){
             }
         }
 
-        model.savePlySplat(outputScene);
+        model.save(outputScene);
         // model.saveDebugPly("debug.ply");
 
         // Validate

--- a/spherical_harmonics.cpp
+++ b/spherical_harmonics.cpp
@@ -24,7 +24,7 @@ torch::Tensor rgb2sh(const torch::Tensor &rgb){
 
 torch::Tensor sh2rgb(const torch::Tensor &sh){
     // Converts from 0th spherical harmonic coefficients to RGB values [0,1]
-    return (sh * C0) + 0.5;
+    return torch::clamp((sh * C0) + 0.5, 0.0f, 1.0f);
 }
 
 #if defined(USE_HIP) || defined(USE_CUDA) || defined(USE_MPS)


### PR DESCRIPTION
Adds support for generating `.splat` files directly for use in viewers such as https://github.com/antimatter15/splat or https://projects.markkellogg.org/threejs/gaussian_splats_3d_demos/truck.html

Closes #8 