### PR TITLE
Fix nvcc warning (#20012-D)

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Ubuntu CUDA)
 on:
   push:
     branches:
-      - fix-nvcc-warning-20012
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Ubuntu CUDA)
 on:
   push:
     branches:
-      - main
+      - fix-nvcc-warning-20012
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)
 endif()
+# Suppress warning #20012-D (nvcc and glm)
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -diag-suppress=20012)
+
 include(FetchContent)
 FetchContent_Declare(nlohmann_json
     URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip


### PR DESCRIPTION
This PR is trying to suppress the build warning emitted from glm when compiling with nvcc. The root cause is probably related to the tagged upstream glm repo. 