### PR TITLE
Enable libtorch 2.3.x build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Docker CUDA)
 on:
   push:
     branches:
-      - torch-2.3.x
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Docker CUDA)
 on:
   push:
     branches:
-      - main
+      - torch-2.3.x
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-22.04] # [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
         arch: [x64] # [x64, x86]
         ubuntu-version: [22.04, 20.04] # [18.04, 20.04, 22.04]
-        torch-version: [2.1.2] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.3.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         cuda-version: [11.8.0] # [12.3.1, 12.1.1, 11.8.0, 11.7.1, 11.6.2, 11.5.2,11.4.4, 11.3.1, 11.2.2, 11.1.1, 11.0.3, cpu]
         cmake-build-type: [Release] # [Debug, ClangTidy]
     steps:

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Ubuntu ROCm/HIP)
 on:
   push:
     branches:
-      - main
+      - torch-2.3.x
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04] # [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
         arch: [x64] # [x64, x86]
-        torch-version: [2.2.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.3.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         cuda-version: [11.8.0] # [12.3.2, 12.3.1, 12.1.1, 11.8.0, 11.7.1, 11.6.2, 11.5.2,11.4.4, 11.3.1, 11.2.2, 11.1.1, 11.0.3, cpu]
         rocm-version: [5.7.1] # [5.4.2, 5.6.1, 5.7.1, 6.0.1, 6.0.2]
         llvm-version: [16] # [12, 13, 14, 15, 16, 17]

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Ubuntu ROCm/HIP)
 on:
   push:
     branches:
-      - torch-2.3.x
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: OpenSplat (MacOS X86 and ARM)
 on:
   push:
     branches:
-      - main
+      - torch-2.3.x
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [macos-14, macos-13] # [macos-14, macos-13, macos-12, macos-11]
         arch: [arm64, x86_64] # [arm64, x86_64]
-        torch-version: [2.2.1, 2.1.2] # [2.2.1, 2.2.0, 2.1.2, 2.1.1, 2.1.0, 2.0.0, 1.13.0, 1.12.0]
+        torch-version: [2.3.1] # [2.2.1, 2.2.0, 2.1.2, 2.1.1, 2.1.0, 2.0.0, 1.13.0, 1.12.0]
         cmake-build-type: [Release] # [Debug, ClangTidy]
         exclude:
           - os: macos-14
@@ -73,8 +73,10 @@ jobs:
         run: |
           TORCH_VER_FULL=${{ matrix.torch-version }}
           TORCH_VER_ARR=($(echo ${TORCH_VER_FULL} | tr "." " "))
-          TORCH_VER="${TORCH_VER_ARR[0]}.${TORCH_VER_ARR[1]}"
-          if [[ "${TORCH_VER}" == "2.2" ]]; then
+          TORCH_MAJOR_VER="${TORCH_VER_ARR[0]}"
+          TORCH_MINOR_VER="${TORCH_VER_ARR[1]}"
+          TORCH_VER="${TORCH_MAJOR_VER}.${TORCH_MINOR_VER}"
+          if [[ $TORCH_MAJOR_VER -gt 2 ]] || { [[ $TORCH_MAJOR_VER -eq 2 ]] && [[ $TORCH_MINOR_VER -gt 1 ]]; }; then
             wget --no-check-certificate -nv https://download.pytorch.org/libtorch/cpu/libtorch-macos-${{ matrix.arch }}-${{ matrix.torch-version }}.zip -O libtorch.zip
           else
             wget --no-check-certificate -nv https://download.pytorch.org/libtorch/cpu/libtorch-macos-${{ matrix.torch-version }}.zip -O libtorch.zip

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,6 +27,9 @@ jobs:
             arch: arm64
             torch-version: 2.1.2
           - os: macos-13
+            arch: x86_64
+            torch-version: 2.3.1
+          - os: macos-13
             arch: arm64
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: OpenSplat (MacOS X86 and ARM)
 on:
   push:
     branches:
-      - torch-2.3.x
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [macos-14, macos-13] # [macos-14, macos-13, macos-12, macos-11]
         arch: [arm64, x86_64] # [arm64, x86_64]
-        torch-version: [2.3.1] # [2.2.1, 2.2.0, 2.1.2, 2.1.1, 2.1.0, 2.0.0, 1.13.0, 1.12.0]
+        torch-version: [2.3.1, 2.2.1, 2.1.2] # [2.2.1, 2.2.0, 2.1.2, 2.1.1, 2.1.0, 2.0.0, 1.13.0, 1.12.0]
         cmake-build-type: [Release] # [Debug, ClangTidy]
         exclude:
           - os: macos-14

--- a/.github/workflows/rocm6.yml
+++ b/.github/workflows/rocm6.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Docker ROCm 6.x)
 on:
   push:
     branches:
-      - torch-2.3.x
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04] # [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
         arch: [x64] # [x64, x86]
-        torch-version: [2.3.1, 2.1.2] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.1.2] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         rocm-version: [6.0.2]
         cmake-build-type: [Release] # [Debug, ClangTidy]
     steps:

--- a/.github/workflows/rocm6.yml
+++ b/.github/workflows/rocm6.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Docker ROCm 6.x)
 on:
   push:
     branches:
-      - main
+      - torch-2.3.x
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04] # [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
         arch: [x64] # [x64, x86]
-        torch-version: [2.1.2] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.3.1, 2.1.2] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         rocm-version: [6.0.2]
         cmake-build-type: [Release] # [Debug, ClangTidy]
     steps:

--- a/.github/workflows/ubuntu-cpu.yml
+++ b/.github/workflows/ubuntu-cpu.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Ubuntu CPU)
 on:
   push:
     branches:
-      - main
+      - torch-2.3.x
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04] # [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
         arch: [x64] # [x64, x86]
-        torch-version: [2.1.2, 2.2.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.3.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         cmake-build-type: [Release] # [Debug, ClangTidy]
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache

--- a/.github/workflows/ubuntu-cpu.yml
+++ b/.github/workflows/ubuntu-cpu.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Ubuntu CPU)
 on:
   push:
     branches:
-      - torch-2.3.x
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04] # [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
         arch: [x64] # [x64, x86]
-        torch-version: [2.3.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.3.1, 2.2.1, 2.1.2] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         cmake-build-type: [Release] # [Debug, ClangTidy]
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Ubuntu CUDA)
 on:
   push:
     branches:
-      - main
+      - torch-2.3.x
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04] # [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
         arch: [x64] # [x64, x86]
-        torch-version: [2.1.2, 2.2.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.3.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         cuda-version: [11.8.0, 12.1.1] # [12.3.1, 12.1.1, 11.8.0, 11.7.1, 11.6.2, 11.5.2,11.4.4, 11.3.1, 11.2.2, 11.1.1, 11.0.3, cpu]
         cmake-build-type: [Release] # [Debug, ClangTidy]
     env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Ubuntu CUDA)
 on:
   push:
     branches:
-      - torch-2.3.x
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04] # [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
         arch: [x64] # [x64, x86]
-        torch-version: [2.3.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.3.1, 2.2.1, 2.1.2] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         cuda-version: [11.8.0, 12.1.1] # [12.3.1, 12.1.1, 11.8.0, 11.7.1, 11.6.2, 11.5.2,11.4.4, 11.3.1, 11.2.2, 11.1.1, 11.0.3, cpu]
         cmake-build-type: [Release] # [Debug, ClangTidy]
     env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Windows CUDA)
 on:
   push:
     branches:
-      - torch-2.3.x
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [windows-2019, windows-2022] # [windows-2019, windows-2022]
         arch: [x64] # [x64, x86]
-        torch-version: [2.3.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.3.1, 2.2.1, 2.1.2] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         cuda-version: [11.8.0, 12.1.1] # [12.3.1, 12.1.1, 11.8.0, 11.7.1, 11.6.2, 11.5.2,11.4.4, 11.3.1, 11.2.2, 11.1.1, 11.0.3, cpu]
         opencv-version: [4.9.0] # [4.7.0, 4.8.1, 4.9.0]
         cmake-build-type: [ Release ] # [Debug, ClangTidy]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: OpenSplat (Windows CUDA)
 on:
   push:
     branches:
-      - main
+      - torch-2.3.x
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [windows-2019, windows-2022] # [windows-2019, windows-2022]
         arch: [x64] # [x64, x86]
-        torch-version: [2.1.2, 2.2.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
+        torch-version: [2.3.1] # [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1]
         cuda-version: [11.8.0, 12.1.1] # [12.3.1, 12.1.1, 11.8.0, 11.7.1, 11.6.2, 11.5.2,11.4.4, 11.3.1, 11.2.2, 11.1.1, 11.0.3, cpu]
         opencv-version: [4.9.0] # [4.7.0, 4.8.1, 4.9.0]
         cmake-build-type: [ Release ] # [Debug, ClangTidy]


### PR DESCRIPTION
This PR activates the latest libtorch 2.3.x build across different platforms. 

Note: Currently, windows-2022 is failing. I'll fix this build issue from a different PR. Github Actions bumped up the cuda requirement for Windows agents recently. 