### PR TITLE
Implement 2d image mask support

### DIFF
--- a/colmap.cpp
+++ b/colmap.cpp
@@ -24,6 +24,8 @@ InputData inputDataFromColmap(const std::string &projectRoot){
     if (!fs::exists(imagesPath)) throw std::runtime_error(imagesPath.string() + " does not exist");
     if (!fs::exists(pointsPath)) throw std::runtime_error(pointsPath.string() + " does not exist");
 
+    const bool maskDirExists = fs::exists(fs::path(projectRoot) / "masks");
+
     std::ifstream camf(camerasPath.string(), std::ios::binary);
     if (!camf.is_open()) throw std::runtime_error("Cannot open " + camerasPath.string());
     std::ifstream imgf(imagesPath.string(), std::ios::binary);
@@ -114,6 +116,7 @@ InputData inputDataFromColmap(const std::string &projectRoot){
 
         // TODO: should "images" be an option?
         cam.filePath = (fs::path(projectRoot) / "images" / filePath).string();
+        if (maskDirExists) cam.maskPath = (fs::path(projectRoot) / "masks" / (filePath + ".png")).string();
 
         unorientedPoses[i].index_put_({Slice(None, 3), Slice(None, 3)}, Rinv);
         unorientedPoses[i].index_put_({Slice(None, 3), Slice(3, 4)}, Tinv);

--- a/cv_utils.cpp
+++ b/cv_utils.cpp
@@ -36,8 +36,8 @@ cv::Mat tensorToImage(const torch::Tensor &t){
     return image;
 }
 
-torch::Tensor imageToTensor(const cv::Mat &image){
+torch::Tensor imageToTensor(const cv::Mat &image, const torch::Dtype dataType){
     torch::Tensor img = torch::from_blob(image.data, { image.rows, image.cols, image.dims + 1 }, torch::kU8);
-    return (img.toType(torch::kFloat32) / 255.0f);
+    return img.toType(dataType);
 }
 

--- a/cv_utils.hpp
+++ b/cv_utils.hpp
@@ -11,6 +11,6 @@ void imwriteRGB(const std::string &filename, const cv::Mat &image);
 cv::Mat floatNxNtensorToMat(const torch::Tensor &t);
 torch::Tensor floatNxNMatToTensor(const cv::Mat &m);
 cv::Mat tensorToImage(const torch::Tensor &t);
-torch::Tensor imageToTensor(const cv::Mat &image);
+torch::Tensor imageToTensor(const cv::Mat &image, const torch::Dtype dataType);
 
 #endif

--- a/input_data.cpp
+++ b/input_data.cpp
@@ -33,7 +33,7 @@ torch::Tensor Camera::getIntrinsicsMatrix(){
                           {0.0f, 0.0f, 1.0f}}, torch::kFloat32);
 }
 
-torch::Tensor Camera::undistortImage(cv::Mat &cImg, torch::Tensor &_K, bool shouldUpdateK, const torch::Dtype dataType){
+torch::Tensor Camera::undistortTensor(cv::Mat &cImg, torch::Tensor &_K, bool shouldUpdateK, const torch::Dtype dataType){
     cv::Rect roi;
 
     torch::Tensor t;
@@ -90,7 +90,7 @@ void Camera::loadImage(float downscaleFactor){
     }
 
     K = getIntrinsicsMatrix();
-    image = undistortImage(cImg, K, true, torch::kFloat32) / 255.0f;
+    image = undistortTensor(cImg, K, true, torch::kFloat32) / 255.0f;
 
     // Update parameters
     height = image.size(0);
@@ -116,7 +116,7 @@ void Camera::loadMask(float downscaleFactor){
         }
 
         torch::Tensor _K = getIntrinsicsMatrix();
-        mask = ~undistortImage(cImg, _K, false, torch::kBool);
+        mask = ~undistortTensor(cImg, _K, false, torch::kBool);
     }
 }
 

--- a/input_data.hpp
+++ b/input_data.hpp
@@ -24,25 +24,35 @@ struct Camera{
     float p2 = 0;
     torch::Tensor camToWorld;
     std::string filePath = "";
+    std::string maskPath = "";
     CameraType cameraType = CameraType::Perspective;
 
     Camera(){};
     Camera(int width, int height, float fx, float fy, float cx, float cy, 
         float k1, float k2, float k3, float p1, float p2,
-        const torch::Tensor &camToWorld, const std::string &filePath) : 
+        const torch::Tensor &camToWorld, const std::string &filePath,
+        const std::string &maskPath) :
         width(width), height(height), fx(fx), fy(fy), cx(cx), cy(cy), 
         k1(k1), k2(k2), k3(k3), p1(p1), p2(p2),
-        camToWorld(camToWorld), filePath(filePath) {}
+        camToWorld(camToWorld), filePath(filePath), maskPath(maskPath) {}
     torch::Tensor getIntrinsicsMatrix();
     bool hasDistortionParameters();
     std::vector<float> undistortionParameters();
     torch::Tensor getImage(int downscaleFactor);
+    torch::Tensor getMask(int downscaleFactor);
 
     void loadImage(float downscaleFactor);
+    void loadMask(float downscaleFactor);
     torch::Tensor K;
     torch::Tensor image;
+    torch::Tensor mask;
 
     std::unordered_map<int, torch::Tensor> imagePyramids;
+    std::unordered_map<int, torch::Tensor> maskPyramids;
+
+  private:
+    torch::Tensor undistortImage(cv::Mat &cImg, torch::Tensor &_K, bool shouldUpdateK, const torch::Dtype dataType);
+    torch::Tensor getScaledStoredTensor(int downscaleFactor, torch::Tensor &tensor, std::unordered_map<int, torch::Tensor> &map, const torch::Dtype dataType, const float normalizeBy);
 };
 
 struct Points{

--- a/input_data.hpp
+++ b/input_data.hpp
@@ -51,7 +51,7 @@ struct Camera{
     std::unordered_map<int, torch::Tensor> maskPyramids;
 
   private:
-    torch::Tensor undistortImage(cv::Mat &cImg, torch::Tensor &_K, bool shouldUpdateK, const torch::Dtype dataType);
+    torch::Tensor undistortTensor(cv::Mat &cImg, torch::Tensor &_K, bool shouldUpdateK, const torch::Dtype dataType);
     torch::Tensor getScaledStoredTensor(int downscaleFactor, torch::Tensor &tensor, std::unordered_map<int, torch::Tensor> &map, const torch::Dtype dataType, const float normalizeBy);
 };
 

--- a/nerfstudio.cpp
+++ b/nerfstudio.cpp
@@ -153,7 +153,7 @@ InputData inputDataFromNerfStudio(const std::string &projectRoot){
                             static_cast<float>(f.k1), static_cast<float>(f.k2), static_cast<float>(f.k3), 
                             static_cast<float>(f.p1), static_cast<float>(f.p2),  
                             
-                            poses[i], (nsRoot / f.filePath).string()));
+                            poses[i], (nsRoot / f.filePath).string(), "")); // TODO: Get mask, if it exists. See reference: https://github.com/nerfstudio-project/nerfstudio/blob/main/nerfstudio/models/splatfacto.py
     }
 
     torch::Tensor points = pSet->pointsTensor().clone();

--- a/nerfstudio.cpp
+++ b/nerfstudio.cpp
@@ -15,6 +15,7 @@ namespace ns{
 
 void to_json(json &j, const Frame &f){
     j = json{ {"file_path", f.filePath }, 
+                {"mask_path", f.maskPath },
                 {"w", f.width }, 
                 {"h", f.height },
                 {"fl_x", f.fx },
@@ -33,6 +34,7 @@ void to_json(json &j, const Frame &f){
 
 void from_json(const json& j, Frame &f){
     j.at("file_path").get_to(f.filePath);
+    if (j.contains("mask_path")) j.at("mask_path").get_to(f.maskPath);
     j.at("transform_matrix").get_to(f.transformMatrix);
     if (j.contains("w")) j.at("w").get_to(f.width);
     if (j.contains("h")) j.at("h").get_to(f.height);
@@ -153,7 +155,7 @@ InputData inputDataFromNerfStudio(const std::string &projectRoot){
                             static_cast<float>(f.k1), static_cast<float>(f.k2), static_cast<float>(f.k3), 
                             static_cast<float>(f.p1), static_cast<float>(f.p2),  
                             
-                            poses[i], (nsRoot / f.filePath).string(), "")); // TODO: Get mask, if it exists. See reference: https://github.com/nerfstudio-project/nerfstudio/blob/main/nerfstudio/models/splatfacto.py
+                            poses[i], (nsRoot / f.filePath).string(), (nsRoot / f.maskPath).string()));
     }
 
     torch::Tensor points = pSet->pointsTensor().clone();

--- a/nerfstudio.hpp
+++ b/nerfstudio.hpp
@@ -15,6 +15,7 @@ namespace ns{
 
     struct Frame{
         std::string filePath = "";
+        std::string maskPath = "";
         int width = 0;
         int height = 0;
         double fx = 0;

--- a/opensfm.cpp
+++ b/opensfm.cpp
@@ -122,7 +122,7 @@ InputData inputDataFromOpenSfM(const std::string &projectRoot){
                             static_cast<float>(c.k1), static_cast<float>(c.k2), static_cast<float>(c.k3), 
                             static_cast<float>(c.p1), static_cast<float>(c.p2),  
                             
-                            poses[i++], images[filename]));
+                            poses[i++], images[filename], "")); // TODO: Is it possible to have image masks from this format?
     }
 
     size_t numPoints = points.size();


### PR DESCRIPTION
Closes issue #35 

This implements the ability to use masks, either from colmap's format (`masks/<image_name>.png`) or from nerfstudio (`mask_path`).

The main utility of this is for a scene in which the object of interest is moving independently of other objects, or the user wants to speed up the calculations or reduce the VRAM requirements of the scene. Users should not expect the quality of a splat produced with masking to be superior to the same splat produced without masking (if both have gone through the same number of iterations).

Users should also note that, when using colmap's format, the mask is expected to end in an *additional* `.png`, even if the image file is a `.png`. For example, an image file `image1.png`'s mask should be `image1.png.png`. This is colmap's format of choice.

In the future I might look into an improvement @pierotofy suggested - modifying the SSIM/L1 functions to ignore the mask areas - to avoid a possible problem with sparse masks (see discussion in issue #35 for more detail).