### PR TITLE
Allow overriding input image path when using COLMAP

### DIFF
--- a/colmap.cpp
+++ b/colmap.cpp
@@ -8,7 +8,7 @@ using namespace torch::indexing;
 
 namespace cm{
 
-InputData inputDataFromColmap(const std::string &projectRoot){
+InputData inputDataFromColmap(const std::string &projectRoot, const std::string& colmapImageSourcePath){
     InputData ret;
     fs::path cmRoot(projectRoot);
 
@@ -112,8 +112,10 @@ InputData inputDataFromColmap(const std::string &projectRoot){
             filePath += ch;
         }
 
-        // TODO: should "images" be an option?
-        cam.filePath = (fs::path(projectRoot) / "images" / filePath).string();
+        if (colmapImageSourcePath.empty())
+            cam.filePath = (fs::path(projectRoot) / "images" / filePath).string();
+        else
+            cam.filePath = (fs::path(colmapImageSourcePath) / filePath).string();
 
         unorientedPoses[i].index_put_({Slice(None, 3), Slice(None, 3)}, Rinv);
         unorientedPoses[i].index_put_({Slice(None, 3), Slice(3, 4)}, Tinv);

--- a/colmap.hpp
+++ b/colmap.hpp
@@ -5,7 +5,7 @@
 #include "input_data.hpp"
 
 namespace cm{
-    InputData inputDataFromColmap(const std::string &projectRoot);
+    InputData inputDataFromColmap(const std::string &projectRoot, const std::string& colmapImageSourcePath = "");
 
     enum CameraModel{
         SimplePinhole = 0, Pinhole, SimpleRadial, Radial,

--- a/input_data.cpp
+++ b/input_data.cpp
@@ -8,17 +8,17 @@ using namespace torch::indexing;
 using json = nlohmann::json;
 
 namespace ns{ InputData inputDataFromNerfStudio(const std::string &projectRoot); }
-namespace cm{ InputData inputDataFromColmap(const std::string &projectRoot); }
+namespace cm{ InputData inputDataFromColmap(const std::string &projectRoot, const std::string& imageSourcePath); }
 namespace osfm { InputData inputDataFromOpenSfM(const std::string &projectRoot); }
 namespace omvg { InputData inputDataFromOpenMVG(const std::string &projectRoot); }
 
-InputData inputDataFromX(const std::string &projectRoot){
+InputData inputDataFromX(const std::string &projectRoot, const std::string& colmapImageSourcePath){
     fs::path root(projectRoot);
 
     if (fs::exists(root / "transforms.json")){
         return ns::inputDataFromNerfStudio(projectRoot);
     }else if (fs::exists(root / "sparse") || fs::exists(root / "cameras.bin")){
-        return cm::inputDataFromColmap(projectRoot);
+        return cm::inputDataFromColmap(projectRoot, colmapImageSourcePath);
     }else if (fs::exists(root / "reconstruction.json")){
         return osfm::inputDataFromOpenSfM(projectRoot);
     }else if (fs::exists(root / "opensfm" / "reconstruction.json")){

--- a/input_data.hpp
+++ b/input_data.hpp
@@ -59,6 +59,7 @@ struct InputData{
 
     void saveCameras(const std::string &filename, bool keepCrs);
 };
-InputData inputDataFromX(const std::string &projectRoot);
+// The colmapImageSourcePath is only used in Colmap. In other methods, this path is ignored.
+InputData inputDataFromX(const std::string& projectRoot, const std::string& colmapImageSourcePath = "");
 
 #endif

--- a/opensplat.cpp
+++ b/opensplat.cpp
@@ -41,6 +41,7 @@ int main(int argc, char *argv[]){
         ("densify-size-thresh", "Gaussians' scales below this threshold are duplicated, otherwise split", cxxopts::value<float>()->default_value("0.01"))
         ("stop-screen-size-at", "Stop splitting gaussians that are larger than [split-screen-size] after these many steps", cxxopts::value<int>()->default_value("4000"))
         ("split-screen-size", "Split gaussians that are larger than this percentage of screen space", cxxopts::value<float>()->default_value("0.05"))
+        ("colmap-image-path", "Override the default image path for COLMAP-based input", cxxopts::value<std::string>()->default_value(""))
 
         ("h,help", "Print usage")
         ("version", "Print version")
@@ -90,6 +91,7 @@ int main(int argc, char *argv[]){
     const float densifySizeThresh = result["densify-size-thresh"].as<float>();
     const int stopScreenSizeAt = result["stop-screen-size-at"].as<int>();
     const float splitScreenSize = result["split-screen-size"].as<float>();
+    const std::string colmapImageSourcePath = result["colmap-image-path"].as<std::string>();
 
     torch::Device device = torch::kCPU;
     int displayStep = 10;
@@ -111,7 +113,7 @@ int main(int argc, char *argv[]){
 #endif
 
     try{
-        InputData inputData = inputDataFromX(projectRoot);
+        InputData inputData = inputDataFromX(projectRoot, colmapImageSourcePath);
 
         parallel_for(inputData.cameras.begin(), inputData.cameras.end(), [&downScaleFactor](Camera &cam){
             cam.loadImage(downScaleFactor);


### PR DESCRIPTION
This PR introduces the colmap-image-path option, allowing users to specify a custom path for input images when using a COLMAP reconstruction as input. This is useful when the default image path does not match the desired directory structure.