### PR TITLE
Enable OpenSplat on AMD Radeon R9700 graphic card with ROCm 7.0.0 and libtorch 2.5.1

### DIFF
--- a/Dockerfile.rocm7
+++ b/Dockerfile.rocm7
@@ -1,0 +1,39 @@
+ARG UBUNTU_VERSION=24.04
+ARG TORCH_VERSION=2.5.1
+ARG ROCM_VERSION=7.0
+FROM rocm/pytorch:rocm${ROCM_VERSION}_ubuntu24.04_py3.12_pytorch_release_${TORCH_VERSION}
+
+ARG LLVM_VERSION=19
+ARG CMAKE_BUILD_TYPE=Release
+
+SHELL ["/bin/bash", "-c"]
+
+# Env variables
+ENV DEBIAN_FRONTEND noninteractive
+
+# Prepare directories
+WORKDIR /code
+
+# Copy everything
+COPY . ./
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    libopencv-dev && \
+    apt-get autoremove -y --purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure and build \
+RUN source activate py_3.12 && \
+    mkdir build && \
+    cd build && \
+    cmake .. \
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+      -DGPU_RUNTIME=HIP \
+      -DHIP_ROOT_DIR=/opt/rocm \
+      -DOPENSPLAT_BUILD_SIMPLE_TRAINER=ON \
+      -DCMAKE_PREFIX_PATH=/opt/venv/lib/python3.12/site-packages/torch \
+      -DCMAKE_INSTALL_PREFIX=/code/install && \
+    make


### PR DESCRIPTION
Porting the gaussian algorithm with ROCm 7.0.0 and Torch 2.5.1. 
It's verified on AMD Radeon R9700 with RDNA4 arch. The training loss could converage with this new configuration which will failed with ROCm <=6.4.x.
<img width="745" height="568" alt="image" src="https://github.com/user-attachments/assets/de771d69-3ca1-4c66-b226-aa34578c8645" />
