### PR TITLE
fix: correct misleading error message when colorized.ply is missing

### DIFF
--- a/openmvg.cpp
+++ b/openmvg.cpp
@@ -240,7 +240,7 @@ InputData inputDataFromOpenMVG(const std::string &projectRoot){
         throw std::runtime_error("No colorized.ply found, cloud_and_poses found, please run openMVG_main_ComputeSfM_DataColor and name the output colorized.ply");
     }
     if (!fs::exists(cmRoot / "cloud_and_poses.ply") && !fs::exists(colorPointCloud)){
-        throw std::runtime_error("No project files found, please check the file path for sfm_data.json or sfm_data.bin");
+        throw std::runtime_error("No colorized.ply found, cloud_and_poses.ply found, please run openMVG_main_ComputeSfM_DataColor and name the output colorized.ply");
     }
 
     std::ifstream f(reconstructionPath.string());


### PR DESCRIPTION
Fixes pierotofy/OpenSplat#171

**Problem:** When cloud_and_poses.ply is found but colorized.ply is missing, the error message incorrectly says "No project files found, please check the file path for sfm_data.json or sfm_data.bin", which is confusing because all the expected project files actually exist.

**Fix:** Correct line 243 in openmvg.cpp to reference the missing file (colorized.ply) and the file that was found (cloud_and_poses.ply), matching the exact wording used on line 240 for the same condition.