### PR TITLE
CMakeLists.txt: Allow disabling FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ set(OPENSPLAT_MAX_CUDA_COMPATIBILITY OFF CACHE BOOL "Build for maximum CUDA devi
 set(OPENSPLAT_BUILD_VISUALIZER OFF CACHE BOOL "Build visualizer application")
 set(OPENSPLAT_USE_FAST_MATH OFF CACHE BOOL "Enable fast math optimizations for GPU kernels (-use_fast_math / -ffast-math)")
 
+set(FETCH_NLOHMANN_JSON ON CACHE BOOL "Fetch the nlohmann_json dependency from the Internet during configuration")
+set(FETCH_NANOFLANN ON CACHE BOOL "Fetch the nanoflann dependency from the Internet during configuration")
+set(FETCH_CXXOPTS ON CACHE BOOL "Fetch the cxxopts dependency from the Internet during configuration")
+set(FETCH_GLM ON CACHE BOOL "Fetch the glm dependency from the Internet during configuration")
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Read version
@@ -45,24 +50,46 @@ if(OPENSPLAT_USE_FAST_MATH)
     set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} --use_fast_math)
 endif()
 
+# Fetch/find additional dependencies
 include(FetchContent)
-FetchContent_Declare(nlohmann_json
-    URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip
-)
+if(FETCH_NLOHMANN_JSON)
+    FetchContent_Declare(nlohmann_json
+        URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+else()
+    find_package(nlohmann_json)
+endif()
+
 set(NANOFLANN_BUILD_EXAMPLES OFF)
 set(NANOFLANN_BUILD_TESTS OFF)
-FetchContent_Declare(nanoflann
-    URL https://github.com/jlblancoc/nanoflann/archive/refs/tags/v1.5.5.zip
-)
-FetchContent_Declare(cxxopts
-    URL https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.2.0.zip
-)
-FetchContent_MakeAvailable(nlohmann_json nanoflann cxxopts)
-if((GPU_RUNTIME STREQUAL "CUDA") OR (GPU_RUNTIME STREQUAL "HIP"))
-    FetchContent_Declare(glm
-        URL https://github.com/g-truc/glm/archive/refs/tags/1.0.1.zip
+if(FETCH_NANOFLANN)
+    FetchContent_Declare(nanoflann
+        URL https://github.com/jlblancoc/nanoflann/archive/refs/tags/v1.5.5.zip
     )
-    FetchContent_MakeAvailable(glm)
+    FetchContent_MakeAvailable(nanoflann)
+else()
+    find_package(nanoflann)
+endif()
+
+if(FETCH_CXXOPTS)
+    FetchContent_Declare(cxxopts
+        URL https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.2.0.zip
+    )
+    FetchContent_MakeAvailable(cxxopts)
+else()
+    find_package(cxxopts)
+endif()
+
+if((GPU_RUNTIME STREQUAL "CUDA") OR (GPU_RUNTIME STREQUAL "HIP"))
+    if(FETCH_GLM)
+        FetchContent_Declare(glm
+            URL https://github.com/g-truc/glm/archive/refs/tags/1.0.1.zip
+        )
+        FetchContent_MakeAvailable(glm)
+    else()
+        find_package(glm)
+    endif()
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,7 @@ set(OPENSPLAT_MAX_CUDA_COMPATIBILITY OFF CACHE BOOL "Build for maximum CUDA devi
 set(OPENSPLAT_BUILD_VISUALIZER OFF CACHE BOOL "Build visualizer application")
 set(OPENSPLAT_USE_FAST_MATH OFF CACHE BOOL "Enable fast math optimizations for GPU kernels (-use_fast_math / -ffast-math)")
 
-set(FETCH_NLOHMANN_JSON ON CACHE BOOL "Fetch the nlohmann_json dependency from the Internet during configuration")
-set(FETCH_NANOFLANN ON CACHE BOOL "Fetch the nanoflann dependency from the Internet during configuration")
-set(FETCH_CXXOPTS ON CACHE BOOL "Fetch the cxxopts dependency from the Internet during configuration")
-set(FETCH_GLM ON CACHE BOOL "Fetch the glm dependency from the Internet during configuration")
+set(FETCH_DEPENDENCIES ON CACHE BOOL "Fetch additional dependencies from the Internet during configuration")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
@@ -52,37 +49,28 @@ endif()
 
 # Fetch/find additional dependencies
 include(FetchContent)
-if(FETCH_NLOHMANN_JSON)
-    FetchContent_Declare(nlohmann_json
-        URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip
-    )
-    FetchContent_MakeAvailable(nlohmann_json)
-else()
-    find_package(nlohmann_json)
-endif()
 
 set(NANOFLANN_BUILD_EXAMPLES OFF)
 set(NANOFLANN_BUILD_TESTS OFF)
-if(FETCH_NANOFLANN)
+if(FETCH_DEPENDENCIES)
+    FetchContent_Declare(nlohmann_json
+        URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip
+    )
     FetchContent_Declare(nanoflann
         URL https://github.com/jlblancoc/nanoflann/archive/refs/tags/v1.5.5.zip
     )
-    FetchContent_MakeAvailable(nanoflann)
-else()
-    find_package(nanoflann)
-endif()
-
-if(FETCH_CXXOPTS)
     FetchContent_Declare(cxxopts
         URL https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.2.0.zip
     )
-    FetchContent_MakeAvailable(cxxopts)
+    FetchContent_MakeAvailable(nlohmann_json nanoflann cxxopts)
 else()
+    find_package(nlohmann_json)
+    find_package(nanoflann)
     find_package(cxxopts)
 endif()
 
 if((GPU_RUNTIME STREQUAL "CUDA") OR (GPU_RUNTIME STREQUAL "HIP"))
-    if(FETCH_GLM)
+    if(FETCH_DEPENDENCIES)
         FetchContent_Declare(glm
             URL https://github.com/g-truc/glm/archive/refs/tags/1.0.1.zip
         )


### PR DESCRIPTION
The CMake configuration script fetches four dependencies from the Internet by default. This results in errors on my end in the form of `protocol "https" not supported`.

This patchset simply gates the calls to `FetchContent` that perform this fetching behind the flags `FETCH_NLOHMANN_JSON`, `FETCH_NANOFLANN`, etc. If a dependency's respective FETCH flag is disabled, a traditional call to `find_package` is used instead. For compatibility and consistency reasons, these flags are enabled by default.

Besides fixing the issue stated previously, this patchset also makes configuration faster for people who already have these dependencies downloaded beforehand. In my case, I have a `shell.nix` that contains lists of the dependencies to be downloaded verbatim that I can then set up a shell environment from, and since I have all of these dependencies, fetching them is unnecessary. I have attempted configuring and building on this patchset with all of the `FETCH_*` flags set to `off`, and OpenSplat is able to compile without any issue.